### PR TITLE
Use an XML parser when mangling ids

### DIFF
--- a/src/gg4clj/core.clj
+++ b/src/gg4clj/core.clj
@@ -110,12 +110,12 @@
        (apply merge)))
 
 (defn- mangle-ids
-  [svg]
   "ggplot produces SVGs with elements that have id attributes. These ids are unique within each plot, but are
   generated in such a way that they clash when there's more than one plot in a document. This function takes
   an SVG string and replaces the ids with globally unique ids. It returns a string.
 
   This is a workaround which could be removed if there was a way to generate better SVG in R."
+  [svg]
   (let [svg (xml/parse (java.io.ByteArrayInputStream. (.getBytes svg)))
         smap (fresh-ids svg)
         mangle (fn [x]

--- a/src/gg4clj/core.clj
+++ b/src/gg4clj/core.clj
@@ -124,8 +124,8 @@
                      (for [[k v] x]
                        [k (if (or (= :id k)
                                   (and (string? v)
-                                       (or (string/starts-with? v "#")
-                                           (string/starts-with? v "url(#"))))
+                                       (or (.startsWith v "#")
+                                           (.startsWith v "url(#"))))
                             (smap v)
                             v)]))
                    x))]


### PR DESCRIPTION
On some systems/versions of ggplot the resulting SVGs use single quotes which breaks id mangling. This PR addresses this issue by using an xml parser instead regex for id mangling.
